### PR TITLE
Lock external API versions to allow updates in the future.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
-git+https://github.com/CSCfi/swift-x-account-sharing.git
-git+https://github.com/CSCfi/swift-sharing-request.git
+git+https://github.com/CSCfi/swift-x-account-sharing.git@v0.2.0
+git+https://github.com/CSCfi/swift-sharing-request.git@v0.2.0
 fire
 python-swiftclient
 keystoneauth1

--- a/swift_sharing_tools/__init__.py
+++ b/swift_sharing_tools/__init__.py
@@ -2,6 +2,6 @@
 
 
 __name__ = "swift_sharing_tools"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "CSC Developers"
 __license__ = "MIT License"


### PR DESCRIPTION
### Description
External APIs now have version lock to prevent installing incompatible versions, since the next release would break the production environment otherwise.
