### PR TITLE
Fix Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ setuptools.setup(
         "aiohttp",
         "python-swiftclient",
         "keystoneauth1",
-        "swift_x_account_sharing "
-        "@ git+https://github.com/CSCfi/swift-x-account-sharing.git",
-        "swift_sharing_request "
-        "@ git+https://github.com/CSCfi/swift-sharing-request.git",
         "fire",
+        "swift-x-account-sharing "
+        "@ git+https://github.com/CSCfi/swift-x-account-sharing.git@v0.2.0",
+        "swift-sharing-request "
+        "@ git+https://github.com/CSCfi/swift-sharing-request.git@v0.2.0",
     ],
     extras_require={
         "test": ["tox", "pytest", "pytest-cov", "coverage", "flake8",

--- a/swift_sharing_tools/__init__.py
+++ b/swift_sharing_tools/__init__.py
@@ -2,6 +2,6 @@
 
 
 __name__ = "swift_sharing_tools"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "CSC Developers"
 __license__ = "MIT License"

--- a/swift_sharing_tools/publish.py
+++ b/swift_sharing_tools/publish.py
@@ -154,9 +154,12 @@ class Publish():
         """
         if sys.version_info < (3, 7):
             loop = asyncio.get_event_loop()
-            loop.run_until_complete(asyncio.wait([self._get_access_requests(
-                container
-            )]))
+            recipient_info = loop.run_until_complete(
+                asyncio.gather(*[self._get_access_requests(
+                    container
+                )])
+            )
+            recipient_info = recipient_info[0]
         else:
             recipient_info = asyncio.run(self._get_access_requests(
                 container

--- a/swift_sharing_tools/publish.py
+++ b/swift_sharing_tools/publish.py
@@ -101,11 +101,19 @@ class Publish():
         print("Running POST: %s" % command)
         subprocess.call(command)  # nosec
 
-        asyncio.run(self._push_share(
-            container,
-            [recipient],
-            rights
-        ))
+        if sys.version_info < (3, 7):
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(asyncio.wait([self._push_share(
+                container,
+                [recipient],
+                rights
+            )]))
+        else:
+            asyncio.run(self._push_share(
+                container,
+                [recipient],
+                rights
+            ))
 
     def publish(self, path, recipient, *args):
         """
@@ -144,9 +152,15 @@ class Publish():
 
         Usage: publish_request [id] [file or directory] [access (r, w)]
         """
-        recipient_info = asyncio.run(self._get_access_requests(
-            container
-        ))
+        if sys.version_info < (3, 7):
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(asyncio.wait([self._get_access_requests(
+                container
+            )]))
+        else:
+            recipient_info = asyncio.run(self._get_access_requests(
+                container
+            ))
 
         subprocess.call([  # nosec
             "swift",


### PR DESCRIPTION
### Description
Python 3.6 support was broken due to running async commands with Python 3.7 specific commands. Python 3.6 support is now fixed.
