### PR TITLE
Feature/enable seg uploads

### DIFF
--- a/swift_sharing_tools/__init__.py
+++ b/swift_sharing_tools/__init__.py
@@ -2,6 +2,6 @@
 
 
 __name__ = "swift_sharing_tools"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "CSC Developers"
 __license__ = "MIT License"

--- a/swift_sharing_tools/publish.py
+++ b/swift_sharing_tools/publish.py
@@ -30,6 +30,21 @@ class Publish():
         ret = ret.split("=")[1]
         return ret
 
+    @staticmethod
+    def _check_large_files(
+            path: str
+    ) -> bool:
+        """Check if folder contains large files."""
+        return len(
+            list(filter(
+                lambda x: "Permission denied" not in x,  # Filter inaccessible
+                # Get all files > 5GiB from path recursively
+                subprocess.getoutput(
+                    f"find {path} -type f -size +5G"
+                ).split("\n")
+            ))
+        ) > 0
+
     async def _push_share(
             self,
             container: str,
@@ -186,6 +201,10 @@ class Publish():
 
         self.share(container, recipient, *args)
 
+        # If performed a segmented upload, also share the segments
+        if self._check_large_files(path):
+            self.share(f"{container}_segments", recipient, *args)
+
     def publish_request(
             self,
             container: str,
@@ -223,6 +242,10 @@ class Publish():
         for request in recipient_info:
             if request["owner"] == os.environ.get("OS_PROJECT_ID"):
                 self.share(container, request["user"], *args)
+
+                # If performed a segmented upload, aso share the segments
+                if self._check_large_files(path):
+                    self.share(f"{container}_segments", request["user"], *args)
 
 
 def main():

--- a/swift_sharing_tools/publish.py
+++ b/swift_sharing_tools/publish.py
@@ -178,6 +178,9 @@ class Publish():
             "swift",
             "upload",
             container,
+            "-S",
+            str(os.environ.get("SWIFT_SHARING_UPLOAD_SEGMENT_SIZE",
+                               1024 * 1024 * 1024 * 5)),  # Default to 5GiB
             path
         ])
 
@@ -211,6 +214,9 @@ class Publish():
             "swift",
             "upload",
             container,
+            "-S",
+            str(os.environ.get("SWIFT_SHARING_UPLOAD_SEGMENT_SIZE",
+                               1024 * 1024 * 1024 * 5)),  # Default to 5GiB
             path
         ])
 


### PR DESCRIPTION
### Description
Made uploading large (>5GiB) files as segmented uploads the default behavior.

### Changes
* Make uploading large files as segmented uploads the default behavior
* Make the tool discover if large files were uploaded -> share the segment container automatically as well
* Bump to v0.2.1
